### PR TITLE
Added method matchExact() for pattern exact activator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /vendor
 composer.phar
 composer.lock

--- a/src/Activators/LinkActivator.php
+++ b/src/Activators/LinkActivator.php
@@ -35,7 +35,12 @@ class LinkActivator extends NavActivator
             }
 
             $navPath = parse_url($navPattern, PHP_URL_PATH);
-            $match = strpos($currentPath, $navPath) !== false || fnmatch($navPath, $currentPath);
+
+            if ($nav->patternIsMatchExact()) {
+                $match = $currentPath === $navPath;
+            } else {
+                $match = strpos($currentPath, $navPath) !== false || fnmatch($navPath, $currentPath);
+            }
 
             if ($match) {
                 break;
@@ -58,7 +63,11 @@ class LinkActivator extends NavActivator
 
             parse_str($navQuery, $navQuery);
 
-            $match = empty(array_diff($navQuery, $expectedQuery));
+            if ($nav->patternIsMatchExact()) {
+                $match = $navQuery == $expectedQuery;
+            } else {
+                $match = empty(array_diff($navQuery, $expectedQuery));
+            }
 
             if ($match) {
                 break;

--- a/src/Items/Nav.php
+++ b/src/Items/Nav.php
@@ -63,6 +63,11 @@ interface Nav
     public function getPattern();
 
     /**
+     * @return bool
+     */
+    public function patternIsMatchExact();
+
+    /**
      * @param Nav $nav
      * @return Nav
      */

--- a/src/Items/NavItem.php
+++ b/src/Items/NavItem.php
@@ -15,6 +15,8 @@ abstract class NavItem implements Nav
 
     protected $patterns = [];
 
+    protected $patternMatchExact = false;
+
     abstract public function getText();
 
     abstract public function getUrl();
@@ -97,10 +99,40 @@ abstract class NavItem implements Nav
         return $this;
     }
 
+    public function matchExact($exact = true)
+    {
+        $this->patternMatchExact = $exact;
+
+        return $this;
+    }
+
+    public function patternIsMatchExact()
+    {
+        return $this->patternMatchExact;
+    }
+
     public function getPattern()
     {
         if (empty($this->patterns)) {
-            $this->match(parse_url($this->getUrl(), PHP_URL_PATH));
+            $path = parse_url($this->getUrl(), PHP_URL_PATH);
+            $query = parse_url($this->getUrl(), PHP_URL_QUERY);
+            $fragment = parse_url($this->getUrl(), PHP_URL_FRAGMENT);
+
+            $relavtiveUrl = '';
+            
+            if ($path) {
+                $relavtiveUrl = $path;
+            }
+            
+            if ($query) {
+                $relavtiveUrl .= '?' . $query;
+            }
+            
+            if ($fragment) {
+                $relavtiveUrl .= '#' . $fragment;
+            }
+
+            $this->match($relavtiveUrl);
         }
 
         return $this->patterns;

--- a/src/Items/NavSeparator.php
+++ b/src/Items/NavSeparator.php
@@ -59,6 +59,11 @@ class NavSeparator implements Nav
         return [];
     }
 
+    public function patternIsMatchExact()
+    {
+        return false;
+    }
+
     public function getType()
     {
         return 'separator';

--- a/src/Modifiers/NavModifier.php
+++ b/src/Modifiers/NavModifier.php
@@ -97,6 +97,11 @@ abstract class NavModifier implements Nav
         return $this->nav->getPattern();
     }
 
+    public function patternIsMatchExact()
+    {
+        return $this->nav->patternIsMatchExact();
+    }
+
     public function toArray()
     {
         return [


### PR DESCRIPTION
Allows the url index link to be inactive while opening child paths.

For example

`Home (has path => /)`

when you are on another path, then Home will always be considered active.

Usually tricked in a way

`Home (has path => /home)`

With the exact pattern feature, when accessing the Home page (/) it will only be active when you are in the root path "/"